### PR TITLE
Fixed ref for tables and figures

### DIFF
--- a/testdoc.tex
+++ b/testdoc.tex
@@ -133,7 +133,7 @@ the figure stays in the position, and (2) it does not take up too much
 space. You can ensure the former by double clicking the figure, then go to
 ``Layout'' tab, and select ``In line with text.'' To ensure the latter, use ``Paste
 Special,'' then select ``Picture.'' You can resize the figure to your desired size
-once it is pasted. Look at Figure ~\ref{fig:test}.
+once it is pasted. Look at Figure~\ref{fig:test}.
 
 % Test image
 \vspace{-0.2cm}
@@ -144,12 +144,12 @@ begin{figure}[h]
 	\hline \\ [-11pt]
 	\includegraphics[scale = 0.45]{Figures/100_episodes_benchmark_20220105-115141_boxplot.png} \\ [-4pt]
 	\hline
-	\addstackgap[7pt]{{\usefont{T1}{ptm}{b}{n}Figure ~\ref{fig:test}.\hspace{0.09cm} Sample caption. Should be bold, centered, and below}}\\
+	\addstackgap[7pt]{{\usefont{T1}{ptm}{b}{n}Figure~\ref{fig:test}.\hspace{0.09cm} Sample caption. Should be bold, centered, and below}}\\
 	\hline
 	\end{array}
 	\]
 	\captionsetup{labelformat=empty}
-	\caption{}\label{fig:test} % To remove "Figure number" and legend. But the figure should be named and added manually to the list of figures.
+	\caption{}\label{fig:test} % To remove "Figure number" and legend. 
 \end{figure}
 \vspace{-0.9cm}
 
@@ -159,7 +159,7 @@ Inserting a table in the text can work well. You may want to adjust the vertical
 spacing of the text in the tables. (In Word, use Format | Paragraph\ldots~and
 then the Line and Page Breaks tab. Generally, text in each field of a table will
 look better if it has equal amounts of spacing above and below it, as in
-Table ~\ref{tab:lme-mean}.)
+Table~\ref{tab:lme-mean}.)
 
 This is what a test table might look like. 
 
@@ -176,7 +176,7 @@ This is what a test table might look like.
 		Setting A 	& 125         & 95          \\ \hline
 		Setting B 	& 85          & 102         \\ \hline
 		Setting C 	& 98          & 85          \\ \hline 
-		\multicolumn{3}{|c|}{\normalsize{{\usefont{T1}{ptm}{b}{n}Table ~\ref{tab:lme-mean}. \hspace{0.09cm} A Very Nice Table}}} \rule{0pt}{3ex} \\ [4pt] \hline
+		\multicolumn{3}{|c|}{\normalsize{{\usefont{T1}{ptm}{b}{n}Table~\ref{tab:lme-mean}. \hspace{0.09cm} A Very Nice Table}}} \rule{0pt}{3ex} \\ [4pt] \hline
 	\end{tabular}
 	\captionsetup{labelformat=empty}
 	\caption{}

--- a/testdoc.tex
+++ b/testdoc.tex
@@ -133,22 +133,23 @@ the figure stays in the position, and (2) it does not take up too much
 space. You can ensure the former by double clicking the figure, then go to
 ``Layout'' tab, and select ``In line with text.'' To ensure the latter, use ``Paste
 Special,'' then select ``Picture.'' You can resize the figure to your desired size
-once it is pasted. Look at Figure~1.
+once it is pasted. Look at Figure ~\ref{fig:test}.
 
 % Test image
 \vspace{-0.2cm}
-\begin{figure}[h]
+begin{figure}[h]
 	\[
 	%	\hspace*{-0.4cm}
 	\begin{array}{|c|}
 	\hline \\ [-11pt]
 	\includegraphics[scale = 0.45]{Figures/100_episodes_benchmark_20220105-115141_boxplot.png} \\ [-4pt]
 	\hline
-	\addstackgap[7pt]{{\usefont{T1}{ptm}{b}{n}Figure 1.\hspace{0.09cm} Sample caption. Should be bold, centered, and below}}\\
+	\addstackgap[7pt]{{\usefont{T1}{ptm}{b}{n}Figure ~\ref{fig:test}.\hspace{0.09cm} Sample caption. Should be bold, centered, and below}}\\
 	\hline
 	\end{array}
 	\]
-	\caption*{}\label{fig:test} % To remove "Figure number" and legend. But the figure should be named and added manually to the list of figures.
+	\captionsetup{labelformat=empty}
+	\caption{}\label{fig:test} % To remove "Figure number" and legend. But the figure should be named and added manually to the list of figures.
 \end{figure}
 \vspace{-0.9cm}
 
@@ -158,7 +159,7 @@ Inserting a table in the text can work well. You may want to adjust the vertical
 spacing of the text in the tables. (In Word, use Format | Paragraph\ldots~and
 then the Line and Page Breaks tab. Generally, text in each field of a table will
 look better if it has equal amounts of spacing above and below it, as in
-Table~1.)
+Table ~\ref{tab:lme-mean}.)
 
 This is what a test table might look like. 
 
@@ -175,9 +176,10 @@ This is what a test table might look like.
 		Setting A 	& 125         & 95          \\ \hline
 		Setting B 	& 85          & 102         \\ \hline
 		Setting C 	& 98          & 85          \\ \hline 
-		\multicolumn{3}{|c|}{\normalsize{{\usefont{T1}{ptm}{b}{n}Table 1. \hspace{0.09cm} A Very Nice Table}}} \rule{0pt}{3ex} \\ [4pt] \hline
+		\multicolumn{3}{|c|}{\normalsize{{\usefont{T1}{ptm}{b}{n}Table ~\ref{tab:lme-mean}. \hspace{0.09cm} A Very Nice Table}}} \rule{0pt}{3ex} \\ [4pt] \hline
 	\end{tabular}
-	\caption*{}
+	\captionsetup{labelformat=empty}
+	\caption{}
 	\label{tab:lme-mean}
 \end{table}
 \egroup


### PR DESCRIPTION
No need to manually number the tables and figures. Using the \captionsetup to generate number without displaying the label.